### PR TITLE
Edit the default.html layout file

### DIFF
--- a/layouts/default.html
+++ b/layouts/default.html
@@ -53,7 +53,7 @@
               {{/ site.author.github }}
               {{# site.author.googleplus }}
                 <li>
-                  <a href="https://profiles.google.com/{{ site.author.google }}" class="zocial googleplus icon" target="_blank"></a>
+                  <a href="https://profiles.google.com/{{ site.author.googleplus }}" class="zocial googleplus icon" target="_blank"></a>
                 </li>
               {{/ site.author.googleplus }}
               {{# site.author.twitter }}


### PR DESCRIPTION
Hi, when adding the googleplus account to site.yml the link don't change, it still the default : http://profiles.google.com

In the line contains the social network icons, forgot to write: site.author.googleplus instead site.author.google

```
{{# site.author.googleplus }}
<li>
<a href="https://profiles.google.com/{{ site.author.google }}" class="zocial googleplus icon" target="_blank"></a>
</li>
{{/ site.author.googleplus }}
```

to 

```
 <a href="https://profiles.google.com/{{ site.author.googleplus }}" class="zocial googleplus icon" target="_blank"></a>
```
